### PR TITLE
feat: coverage for failed value computation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,8 +101,6 @@ lazy val twitter = (projectMatrix in file("odelay-twitter"))
   .settings(
     name := "odelay-twitter",
     libraryDependencies := (scalaVersion.value match {
-      case rewrite if rewrite.startsWith("2.11") =>
-        Seq("com.twitter" % "util-core_2.11" % "21.2.0")
       case rewrite if rewrite.startsWith("2.12") =>
         Seq("com.twitter" %% "util-core" % "22.12.0")
       case _ => Nil

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,9 @@
 import com.softwaremill.SbtSoftwareMillCommon.commonSmlBuildSettings
 import com.softwaremill.Publish.ossPublishSettings
 
-val scala2_11 = "2.11.12"
 val scala2_12 = "2.12.18"
 val scala2_13 = "2.13.12"
-val scala2 = List(scala2_11, scala2_12, scala2_13)
+val scala2 = List(scala2_12, scala2_13)
 val scala3 = List("3.3.1")
 
 val scalatestVersion = "3.2.17"
@@ -111,7 +110,7 @@ lazy val twitter = (projectMatrix in file("odelay-twitter"))
     description := "an odelay.Timer implementation backed by a com.twitter.util.Timer"
   )
   .jvmPlatform(
-    scalaVersions = List(scala2_11, scala2_12),
+    scalaVersions = List(scala2_12),
     settings = commonJvmSettings
   )
   .dependsOn(core, testing % "test->test")

--- a/odelay-core/src/main/scala/Delay.scala
+++ b/odelay-core/src/main/scala/Delay.scala
@@ -3,8 +3,7 @@ package odelay
 import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import java.util.concurrent.CancellationException
-
-import scala.util.control.NonFatal
+import scala.util.Try
 
 /** Provides an interface for producing Delays. Use requires an implicit [[odelay.Timer]] to be in implicit scope.
   * {{{
@@ -80,7 +79,7 @@ abstract class PromisingDelay[T] extends Delay[T] {
 
   /** Completes the Promise with a success if the promise is not already completed */
   protected def completePromise(value: => T): Unit =
-    if (promiseIncomplete) promise.success(value)
+    if (promiseIncomplete) promise.complete(Try(value))
 
   /** @return true if the promise is not completed */
   protected def promiseIncomplete =

--- a/odelay-testing/src/test/scalajs/TimerSpec.scala
+++ b/odelay-testing/src/test/scalajs/TimerSpec.scala
@@ -60,7 +60,7 @@ class TimerSpec extends AsyncFunSpec with BeforeAndAfterAll {
         .map(value => assert(value === true))
     }
 
-    it("successful completion of delayed operations should result in a future success") {
+    it("successful completion of delayed operations should result in a future failure") {
       case object CustomException extends Exception
 
       val future = Delay(1.second)(throw CustomException).future


### PR DESCRIPTION
This simple use-case did not work

```
odelay.Delay(duration) { throw new TimeoutException() }.future
```

_(if there were tests already in the repo I would have added one.)_